### PR TITLE
日曜診療・祝日診療で△と表示すべきところが◯になっているバグを修正

### DIFF
--- a/src/app/shared/medical-institution.ts
+++ b/src/app/shared/medical-institution.ts
@@ -11,6 +11,6 @@ export interface MedicalInstitution {
   url: string;
   memo_openinghours: string;
   location: Location;
-  isOpenSunday: boolean;
-  isOpenHoliday: boolean;
+  isOpenSunday: string;
+  isOpenHoliday: string;
 }

--- a/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
+++ b/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
@@ -1,5 +1,5 @@
 <div class="p-2 bg-gray-50 shadow-xl">
-  <div class="flex mb-4" *ngIf="medicalInstitution.isOpenSunday !== '' and: medicalInstitution.isOpenHoliday !== '' ">
+  <div class="flex mb-4" *ngIf="medicalInstitution.isOpenSunday !== '' || medicalInstitution.isOpenHoliday !== ''">
     <div *ngIf="medicalInstitution.isOpenSunday === '◯'" class="badge bg-red-100 mr-1">日曜診療：◯</div>
     <div *ngIf="medicalInstitution.isOpenHoliday === '◯'" class="badge bg-yellow-100">祝日診療：◯</div>
     <div *ngIf="medicalInstitution.isOpenSunday === '△'" class="badge bg-red-100 mr-1">日曜診療：△</div>

--- a/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
+++ b/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
@@ -1,7 +1,9 @@
 <div class="p-2 bg-gray-50 shadow-xl">
-  <div class="flex mb-4" *ngIf="medicalInstitution.isOpenSunday; and: medicalInstitution.isOpenHoliday">
-    <div *ngIf="medicalInstitution.isOpenSunday" class="badge bg-red-100 mr-1">日曜診療：◯</div>
-    <div *ngIf="medicalInstitution.isOpenHoliday" class="badge bg-yellow-100">祝日診療：◯</div>
+  <div class="flex mb-4" *ngIf="medicalInstitution.isOpenSunday !== '' and: medicalInstitution.isOpenHoliday !== '' ">
+    <div *ngIf="medicalInstitution.isOpenSunday === '◯'" class="badge bg-red-100 mr-1">日曜診療：◯</div>
+    <div *ngIf="medicalInstitution.isOpenHoliday === '◯'" class="badge bg-yellow-100">祝日診療：◯</div>
+    <div *ngIf="medicalInstitution.isOpenSunday === '△'" class="badge bg-red-100 mr-1">日曜診療：△</div>
+    <div *ngIf="medicalInstitution.isOpenHoliday === '△'" class="badge bg-yellow-100">祝日診療：△</div>
   </div>
   <h3 class="text-lg leading-7 font-bold">{{ medicalInstitution.name }}</h3>
   <div class="mb-4 text-sm leading-5 font-normal">

--- a/src/app/shared/ui/medical-institution-card/medical-institution-card.component.ts
+++ b/src/app/shared/ui/medical-institution-card/medical-institution-card.component.ts
@@ -29,8 +29,8 @@ export class MedicalInstitutionCardComponent {
       lat: 0,
       lng: 0,
     },
-    isOpenSunday: false,
-    isOpenHoliday: false,
+    isOpenSunday: '',
+    isOpenHoliday: '',
   };
 
   faMagnifyingGlass = faMagnifyingGlass;


### PR DESCRIPTION
close #79 

# 動作確認方法
東京都/港区で日曜診療・祝日診療を△として検索を行い、添付画像のようになっていればOK
<img width="467" alt="スクリーンショット 2023-10-05 19 48 09" src="https://github.com/cfj-afterpillsearch/search-frontend/assets/79921660/5ecdf169-9d4f-4831-aca7-63886ef8a9d2">