### PR TITLE
iPhone・chromeで、電話をかけるボタンを押すと白い画面が一度挟まる の修正

### DIFF
--- a/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
+++ b/src/app/shared/ui/medical-institution-card/medical-institution-card.component.html
@@ -21,19 +21,25 @@
     ></div>
   </div>
   <div class="flex-col space-y-4">
-    <button
+    <a
       class="bg-blue-300 p-2 w-full h-12 flex items-center shadow"
+      [attr.href]="'https://www.google.com/search?q=' + medicalInstitution.name"
+      target="_blank"
       (click)="searchButtonPushTag(medicalInstitution)"
     >
       <fa-icon [icon]="faMagnifyingGlass" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">この医療機関を検索して調べる</div>
-    </button>
-    <button class="bg-blue-300 p-2 w-full h-12 flex items-center shadow" (click)="telButtonPushTag(medicalInstitution)">
+    </a>
+    <a
+      class="bg-blue-300 p-2 w-full h-12 flex items-center shadow"
+      [attr.href]="'tel:' + medicalInstitution.tel"
+      (click)="telButtonPushTag(medicalInstitution)"
+    >
       <fa-icon [icon]="faPhone" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">
         <div>この医療機関に電話する</div>
         <div>({{ medicalInstitution.tel }})</div>
       </div>
-    </button>
+    </a>
   </div>
 </div>

--- a/src/app/shared/ui/medical-institution-card/medical-institution-card.component.ts
+++ b/src/app/shared/ui/medical-institution-card/medical-institution-card.component.ts
@@ -38,7 +38,6 @@ export class MedicalInstitutionCardComponent {
   faArrowUpRightFromSquare = faArrowUpRightFromSquare;
 
   searchButtonPushTag(medicalInstitution: MedicalInstitution) {
-    window.open(`https://www.google.com/search?q=${medicalInstitution.name}`, '_blank');
     const gtmTag = {
       event: 'medical-institution-search-button-click',
       data: {
@@ -49,7 +48,6 @@ export class MedicalInstitutionCardComponent {
   }
 
   telButtonPushTag(medicalInstitution: MedicalInstitution) {
-    window.open(`tel:${medicalInstitution.tel}`);
     const gtmTag = {
       event: 'medical-institution-tel-button-click',
       data: {

--- a/src/app/shared/ui/pharmacy-card/pharmacy-card.component.html
+++ b/src/app/shared/ui/pharmacy-card/pharmacy-card.component.html
@@ -17,16 +17,25 @@
     <div class="text-base leading-6 font-normal">{{ pharmacy.emergency_contact_phone }}</div>
   </div>
   <div class="flex-col space-y-4">
-    <button class="bg-green-200 p-2 w-full h-12 flex items-center shadow" (click)="searchButtonPushTag(pharmacy)">
+    <a
+      class="bg-green-200 p-2 w-full h-12 flex items-center shadow"
+      [attr.href]="'https://www.google.com/search?q=' + pharmacy.name"
+      target="_blank"
+      (click)="searchButtonPushTag(pharmacy)"
+    >
       <fa-icon [icon]="faMagnifyingGlass" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">この薬局を検索して調べる</div>
-    </button>
-    <button class="bg-green-200 p-2 w-full h-12 flex items-center shadow" (click)="telButtonPushTag(pharmacy)">
+    </a>
+    <a
+      class="bg-green-200 p-2 w-full h-12 flex items-center shadow"
+      [attr.href]="'tel:' + pharmacy.tel"
+      (click)="telButtonPushTag(pharmacy)"
+    >
       <fa-icon [icon]="faPhone" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">
         <div>この薬局に電話する</div>
         <div>({{ pharmacy.tel }})</div>
       </div>
-    </button>
+    </a>
   </div>
 </div>

--- a/src/app/shared/ui/pharmacy-card/pharmacy-card.component.ts
+++ b/src/app/shared/ui/pharmacy-card/pharmacy-card.component.ts
@@ -46,7 +46,6 @@ export class PharmacyCardComponent implements OnInit {
   }
 
   searchButtonPushTag(pharmacy: Pharmacy) {
-    window.open(`https://www.google.com/search?q=${pharmacy.name}`, '_blank');
     const gtmTag = {
       event: 'pharmacy-search-button-click',
       data: {
@@ -57,7 +56,6 @@ export class PharmacyCardComponent implements OnInit {
   }
 
   telButtonPushTag(pharmacy: Pharmacy) {
-    window.open(`tel:${pharmacy.tel}`);
     const gtmTag = {
       event: 'pharmacy-tel-button-click',
       data: {


### PR DESCRIPTION
close #87 
# 動作確認観点
- iPhone・chromeで電話をかけるボタンを押したとき、白い画面が挟まらないこと