### PR TITLE
「検索して調べる」の仕様変更

### DIFF
--- a/src/app/shared/ui/pharmacy-card/pharmacy-card.component.html
+++ b/src/app/shared/ui/pharmacy-card/pharmacy-card.component.html
@@ -19,7 +19,7 @@
   <div class="flex-col space-y-4">
     <a
       class="bg-green-200 p-2 w-full h-12 flex items-center shadow"
-      [attr.href]="'https://www.google.com/search?q=' + pharmacy.name"
+      [attr.href]="'https://www.google.com/search?q=' + pharmacy.name + pharmacy.address"
       target="_blank"
       (click)="searchButtonPushTag(pharmacy)"
     >


### PR DESCRIPTION
pharmacy-card→pharmacy-card.component.htmlの22行目
[attr.href]="'https://www.google.com/search?q=' + pharmacy.name"を [attr.href]="'https://www.google.com/search?q=' + pharmacy.name +pharmacy.address"に変更した。 Fixes #78