### PR TITLE
問い合わせ画面の表示が、画面への遷移方法によって異なる

### DIFF
--- a/src/app/features/about/about.component.html
+++ b/src/app/features/about/about.component.html
@@ -64,6 +64,6 @@
 
   <div class="block">
     <h3 class="chapter">お問い合わせ</h3>
-    <p>お問い合わせは、 <a routerLink="/contact" target="_blank"> こちらのページ </a>よりお願いします。</p>
+    <p>お問い合わせは、 <a routerLink="/contact"> こちらのページ </a>よりお願いします。</p>
   </div>
 </div>


### PR DESCRIPTION
aboutページ経由の問い合わせ画面リンクだけ別タブで開くようになっていたので、同タブで遷移するように変更した

リポジトリ内のリンクを確認したところ、他のリンクは以下のようになっている
- アフターピル検索アプリケーション内のページは同タブで遷移
- アフターピル検索アプリケーション外のページ（ピルにゃんや厚労省、googleアナリティクスなど）は別タブで開く