### PR TITLE
feat: add function of formatting phone number string

### DIFF
--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.html
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.html
@@ -24,15 +24,22 @@
       <div class="text-sm leading-5 font-normal text-left">この{{ itemCategory }}を検索して調べる</div>
     </a>
     <a
+      *ngIf="hasValidPhoneNumber(item.tel)"
       class="{{ buttonBgColor }} p-2 w-full h-12 flex items-center shadow"
-      [attr.href]="generateTelURI(item.tel)"
+      [attr.href]="generateTelURI(extractPhoneNumber(item.tel))"
       (click)="handleClickTelButton(item)"
     >
       <fa-icon [icon]="faPhone" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">
         <div>この{{ itemCategory }}に電話する</div>
-        <div>({{ item.tel }})</div>
+        <div>({{ extractPhoneNumber(item.tel) }})</div>
       </div>
     </a>
+    <div *ngIf="!hasValidPhoneNumber(item.tel)" class="bg-blue-100 p-2 w-full h-12 flex items-center shadow opacity-50">
+      <fa-icon [icon]="faPhone" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
+      <div class="text-sm leading-5 font-normal text-left">
+        <div>{{ getDisplayPhoneNumber(item.tel) }}</div>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.html
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.html
@@ -38,7 +38,7 @@
     <div *ngIf="!hasValidPhoneNumber(item.tel)" class="bg-blue-100 p-2 w-full h-12 flex items-center shadow opacity-50">
       <fa-icon [icon]="faPhone" [size]="'xl'" class="ml-8 mr-4"></fa-icon>
       <div class="text-sm leading-5 font-normal text-left">
-        <div>{{ getDisplayPhoneNumber(item.tel) }}</div>
+        <div>正しい電話番号を取得できませんでした</div>
       </div>
     </div>
   </div>

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
@@ -60,4 +60,139 @@ export class SearchResultItemCardComponent {
   generateTelURI(tel: string) {
     return `tel:${tel}`;
   }
+
+  /**
+   * 括弧付き電話番号をハイフン区切り形式に変換する
+   * 例: (03)1234-5678 → 03-1234-5678（先頭に括弧）
+   *     (090)1234-5678 → 090-1234-5678（先頭に括弧）
+   *     （03）1234-5678 → 03-1234-5678（全角括弧にも対応）
+   *     03(1234)5678 → 03-1234-5678（中間に括弧）
+   *     03（1234）5678 → 03-1234-5678（中間に全角括弧）
+   *     03−1234−5678 → 03-1234-5678（マイナス記号にも対応）
+   *     03ー1234ー5678 → 03-1234-5678（長音記号にも対応）
+   *     03-1234-5678（担当:田中） → 03-1234-5678（末尾の括弧付き文字列を削除）
+   *
+   * @param tel 電話番号文字列
+   * @returns ハイフン区切り形式の電話番号
+   */
+  normalizePhoneNumber(tel: string): string {
+    if (!tel) {
+      return '';
+    }
+
+    // 末尾の括弧で囲われた文字列を削除（半角・全角両対応）
+    // パターン: 末尾に (xxx) または （xxx） がある場合、それを削除
+    const normalized = tel.replace(/[(（][^)）]*[)）]\s*$/g, '').trim();
+
+    // 括弧付き形式を検出（半角・全角・マイナス記号・長音記号対応）
+    // パターン1: (0XX)XXXX-XXXX または （0XX）XXXX－XXXX（先頭に括弧）
+    const headParenPattern = /[(（](0\d{1,4})[)）][-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{3,4})/;
+    const headMatch = normalized.match(headParenPattern);
+
+    if (headMatch) {
+      // 括弧を取り除いてハイフン区切りに変換
+      const areaCode = headMatch[1]; // 市外局番（例: 03, 090）
+      const middlePart = headMatch[2]; // 中間部分
+      const lastPart = headMatch[3]; // 末尾部分
+
+      return `${areaCode}-${middlePart}-${lastPart}`;
+    }
+
+    // パターン2: 0XX(XXXX)XXXX または 0XX（XXXX）XXXX（中間に括弧）
+    const middleParenPattern = /(0\d{1,4})[-－−ー\s]?[(（](\d{1,4})[)）][-－−ー\s]?(\d{3,4})/;
+    const middleMatch = normalized.match(middleParenPattern);
+
+    if (middleMatch) {
+      // 括弧を取り除いてハイフン区切りに変換
+      const firstPart = middleMatch[1]; // 最初の部分（例: 03, 090）
+      const middlePart = middleMatch[2]; // 中間部分
+      const lastPart = middleMatch[3]; // 末尾部分
+
+      return `${firstPart}-${middlePart}-${lastPart}`;
+    }
+
+    // 括弧なしの場合は正規化された文字列を返す
+    return normalized;
+  }
+
+  /**
+   * 文字列からハイフン区切りの電話番号を抽出する
+   * 前後に不要な文字列がある場合は除去して電話番号のみを返す
+   * 括弧付き形式は自動的にハイフン区切りに変換される
+   *
+   * 対応する電話番号形式:
+   * - 固定電話: 0X-XXXX-XXXX, 0XX-XXX-XXXX, 0XXX-XX-XXXX など
+   * - 携帯電話: 090-XXXX-XXXX, 080-XXXX-XXXX, 070-XXXX-XXXX
+   * - フリーダイヤル: 0120-XXX-XXX, 0800-XXX-XXXX
+   * - 括弧付き: (03)1234-5678 → 03-1234-5678 に変換
+   * - 半角ハイフン（-）、全角ハイフン（－）、マイナス記号（−）、長音記号（ー）すべてに対応
+   *
+   * @param tel 電話番号を含む文字列
+   * @returns 抽出された電話番号、見つからない場合は空文字
+   */
+  extractPhoneNumber(tel: string): string {
+    if (!tel || tel.trim() === '') {
+      return '';
+    }
+
+    // まず括弧付き形式を正規化
+    const normalized = this.normalizePhoneNumber(tel);
+    // console.log(normalized);
+    // 日本の電話番号パターンを検索（半角ハイフン、全角ハイフン、マイナス記号、長音記号対応）
+    const phonePattern = /^0[-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{3,4})$/;
+    const match = normalized.match(phonePattern);
+    // console.log(match);
+
+    if (!match) {
+      return '';
+    }
+
+    const extractedNumber = match[0];
+
+    // 全角ハイフン、マイナス記号、長音記号を半角ハイフンに変換
+    const normalizedNumber = extractedNumber.replace(/[－−ー]/g, '-');
+
+    // 抽出した電話番号の桁数チェック（半角ハイフン、全角ハイフン、マイナス記号、長音記号を除去）
+    const digitsOnly = normalizedNumber.replace(/[-－−ー]/g, '');
+
+    // 10桁未満は無効
+    if (digitsOnly.length < 10) {
+      return '';
+    }
+
+    // 11桁の場合、IP電話or携帯電話番号orフリーダイヤル（050, 090, 080, 070, 060, 0800）のみ許可
+    if (digitsOnly.length === 11) {
+      const isMobilePhone = /^(050|090|080|070|060|0800)/.test(digitsOnly);
+      if (!isMobilePhone) {
+        return '';
+      }
+    }
+
+    // 12桁以上は無効
+    if (digitsOnly.length > 11) {
+      return '';
+    }
+
+    return normalizedNumber;
+  }
+
+  /**
+   * 表示用の電話番号を取得する
+   * 電話番号が抽出できない場合はエラーメッセージを返す
+   * @param tel 電話番号文字列
+   * @returns 表示用の電話番号またはエラーメッセージ
+   */
+  getDisplayPhoneNumber(tel: string): string {
+    const phoneNumber = this.extractPhoneNumber(tel);
+    return phoneNumber || '正しい電話番号を取得できませんでした';
+  }
+
+  /**
+   * 電話番号が有効かチェックする
+   * @param tel 電話番号文字列
+   * @returns 有効な場合true
+   */
+  hasValidPhoneNumber(tel: string): boolean {
+    return this.extractPhoneNumber(tel) !== '';
+  }
 }

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
@@ -57,7 +57,10 @@ export class SearchResultItemCardComponent {
     return `https://www.google.com/search?q=${name} ${address}`;
   }
 
-  generateTelURI(tel: string) {
+  generateTelURI(tel: string | null) {
+    if (!tel) {
+      return '';
+    }
     return `tel:${tel}`;
   }
 
@@ -132,11 +135,11 @@ export class SearchResultItemCardComponent {
    * - 括弧付き: (03)1234-5678 → 03-1234-5678 に変換
    *
    * @param tel 電話番号を含む文字列
-   * @returns 抽出された電話番号、見つからない場合は空文字
+   * @returns 抽出された電話番号、見つからない場合はnull
    */
-  extractPhoneNumber(tel: string): string {
+  extractPhoneNumber(tel: string): string | null {
     if (!tel || tel.trim() === '') {
-      return '';
+      return null;
     }
 
     // まず括弧付き形式を正規化
@@ -146,7 +149,7 @@ export class SearchResultItemCardComponent {
     const match = normalized.match(phonePattern);
 
     if (!match) {
-      return '';
+      return null;
     }
 
     const extractedNumber = match[0];
@@ -156,20 +159,20 @@ export class SearchResultItemCardComponent {
 
     // 10桁未満は無効
     if (digitsOnly.length < 10) {
-      return '';
+      return null;
     }
 
     // 11桁の場合、IP電話or携帯電話番号orフリーダイヤル（050, 090, 080, 070, 060, 0800）のみ許可
     if (digitsOnly.length === 11) {
-      const isMobilePhone = /^(050|090|080|070|060|0800)/.test(digitsOnly);
-      if (!isMobilePhone) {
-        return '';
+      const isCorrectPhoneNumber = /^(050|090|080|070|060|0800)/.test(digitsOnly);
+      if (!isCorrectPhoneNumber) {
+        return null;
       }
     }
 
     // 12桁以上は無効
     if (digitsOnly.length > 11) {
-      return '';
+      return null;
     }
 
     return extractedNumber;
@@ -192,6 +195,6 @@ export class SearchResultItemCardComponent {
    * @returns 有効な場合true
    */
   hasValidPhoneNumber(tel: string): boolean {
-    return this.extractPhoneNumber(tel) !== '';
+    return this.extractPhoneNumber(tel) !== null;
   }
 }

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
@@ -154,8 +154,8 @@ export class SearchResultItemCardComponent {
 
     const extractedNumber = match[0];
 
-    // 抽出した電話番号の桁数チェック（半角ハイフンを除去）
-    const digitsOnly = extractedNumber.replace(/[-]/g, '');
+    // 抽出した電話番号の桁数チェック（半角数字以外の文字を除去）
+    const digitsOnly = extractedNumber.replace(/[^0-9]/g, '');
 
     // 10桁未満は無効
     if (digitsOnly.length < 10) {

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
@@ -72,6 +72,9 @@ export class SearchResultItemCardComponent {
    *     03ー1234ー5678 → 03-1234-5678（長音記号にも対応）
    *     03-1234-5678（担当:田中） → 03-1234-5678（末尾の括弧付き文字列を削除）
    *
+   * 全角ハイフン（－）、マイナス記号（−）、長音記号（ー）を半角ハイフンに変換してから処理を行う
+   *
+   *
    * @param tel 電話番号文字列
    * @returns ハイフン区切り形式の電話番号
    */
@@ -83,11 +86,13 @@ export class SearchResultItemCardComponent {
     // 末尾の括弧で囲われた文字列を削除（半角・全角両対応）
     // パターン: 末尾に (xxx) または （xxx） がある場合、それを削除
     const normalized = tel.replace(/[(（][^)）]*[)）]\s*$/g, '').trim();
+    // 全角ハイフン、マイナス記号、長音記号を半角ハイフンに変換
+    const normalizedNumber = normalized.replace(/[－−ー]/g, '-');
 
     // 括弧付き形式を検出（半角・全角・マイナス記号・長音記号対応）
     // パターン1: (0XX)XXXX-XXXX または （0XX）XXXX－XXXX（先頭に括弧）
-    const headParenPattern = /[(（](0\d{1,4})[)）][-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{3,4})/;
-    const headMatch = normalized.match(headParenPattern);
+    const headParenPattern = /[(（](0\d{1,4})[)）][-\s]?(\d{1,4})[-\s]?(\d{3,4})/;
+    const headMatch = normalizedNumber.match(headParenPattern);
 
     if (headMatch) {
       // 括弧を取り除いてハイフン区切りに変換
@@ -99,8 +104,8 @@ export class SearchResultItemCardComponent {
     }
 
     // パターン2: 0XX(XXXX)XXXX または 0XX（XXXX）XXXX（中間に括弧）
-    const middleParenPattern = /(0\d{1,4})[-－−ー\s]?[(（](\d{1,4})[)）][-－−ー\s]?(\d{3,4})/;
-    const middleMatch = normalized.match(middleParenPattern);
+    const middleParenPattern = /(0\d{1,4})[-\s]?[(（](\d{1,4})[)）][-\s]?(\d{3,4})/;
+    const middleMatch = normalizedNumber.match(middleParenPattern);
 
     if (middleMatch) {
       // 括弧を取り除いてハイフン区切りに変換
@@ -112,7 +117,7 @@ export class SearchResultItemCardComponent {
     }
 
     // 括弧なしの場合は正規化された文字列を返す
-    return normalized;
+    return normalizedNumber;
   }
 
   /**
@@ -125,7 +130,6 @@ export class SearchResultItemCardComponent {
    * - 携帯電話: 090-XXXX-XXXX, 080-XXXX-XXXX, 070-XXXX-XXXX
    * - フリーダイヤル: 0120-XXX-XXX, 0800-XXX-XXXX
    * - 括弧付き: (03)1234-5678 → 03-1234-5678 に変換
-   * - 半角ハイフン（-）、全角ハイフン（－）、マイナス記号（−）、長音記号（ー）すべてに対応
    *
    * @param tel 電話番号を含む文字列
    * @returns 抽出された電話番号、見つからない場合は空文字
@@ -137,11 +141,9 @@ export class SearchResultItemCardComponent {
 
     // まず括弧付き形式を正規化
     const normalized = this.normalizePhoneNumber(tel);
-    // console.log(normalized);
-    // 日本の電話番号パターンを検索（半角ハイフン、全角ハイフン、マイナス記号、長音記号対応）
-    const phonePattern = /^0[-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{1,4})[-－−ー\s]?(\d{3,4})$/;
+    // 日本の電話番号パターンを検索
+    const phonePattern = /^0[-\s]?(\d{1,4})[-\s]?(\d{1,4})[-\s]?(\d{3,4})$/;
     const match = normalized.match(phonePattern);
-    // console.log(match);
 
     if (!match) {
       return '';
@@ -149,11 +151,8 @@ export class SearchResultItemCardComponent {
 
     const extractedNumber = match[0];
 
-    // 全角ハイフン、マイナス記号、長音記号を半角ハイフンに変換
-    const normalizedNumber = extractedNumber.replace(/[－−ー]/g, '-');
-
-    // 抽出した電話番号の桁数チェック（半角ハイフン、全角ハイフン、マイナス記号、長音記号を除去）
-    const digitsOnly = normalizedNumber.replace(/[-－−ー]/g, '');
+    // 抽出した電話番号の桁数チェック（半角ハイフンを除去）
+    const digitsOnly = extractedNumber.replace(/[-]/g, '');
 
     // 10桁未満は無効
     if (digitsOnly.length < 10) {
@@ -173,7 +172,7 @@ export class SearchResultItemCardComponent {
       return '';
     }
 
-    return normalizedNumber;
+    return extractedNumber;
   }
 
   /**

--- a/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
+++ b/src/app/shared/ui/search-result-item-card/search-result-item-card.component.ts
@@ -179,17 +179,6 @@ export class SearchResultItemCardComponent {
   }
 
   /**
-   * 表示用の電話番号を取得する
-   * 電話番号が抽出できない場合はエラーメッセージを返す
-   * @param tel 電話番号文字列
-   * @returns 表示用の電話番号またはエラーメッセージ
-   */
-  getDisplayPhoneNumber(tel: string): string {
-    const phoneNumber = this.extractPhoneNumber(tel);
-    return phoneNumber || '正しい電話番号を取得できませんでした';
-  }
-
-  /**
    * 電話番号が有効かチェックする
    * @param tel 電話番号文字列
    * @returns 有効な場合true


### PR DESCRIPTION
## 関連 Issue
close: #81 
<!-- この PR が関連する Issue をリンクしてください。以下のように記述します。 -->
<!-- close: #123 -->

## 変更点
- 電話番号の末尾に数字以外の文字列が含まれるものについては、それを削除して表示するようにしました。
- 電話番号が括弧で区切られているものについて、半角ハイフン区切りに変換して表示するようにしました。
- マイナス記号やカタカナの長音など、半角ハイフンに似た別の記号で区切られていた場合、半角ハイフン区切りに変換して表示するようにしました。
- 電話番号が12桁を超えるもの、またIP電話or携帯電話番号orフリーダイヤル（050, 090, 080, 070, 060, 0800）以外の11桁を超えるものについて、電話ボタンを非活性とするように変更しました。
<img width="896" height="1357" alt="image" src="https://github.com/user-attachments/assets/0471e4f9-87b8-41ae-a162-9195bcb202ad" />

<!-- 具体的な変更点や修正箇所を記載してください。必要に応じて画像や動画を添付してください。　-->

## 影響範囲
影響範囲は特にないです。
<!-- 変更点以外に影響を及ぼす範囲があれば、それを記載してください。 -->

## テスト

<!-- この PR に関連するテストケースやテスト方法を記載してください。 -->
### ボタン活性が期待されるケース
- 半角ハイフンつなぎの10桁固定電話
  - 札幌市中央区　NTT東日本札幌病院
- 11桁携帯電話
  - 東京都豊島区　クリニカ・アンジェラ
- 電話番号の末尾に数字以外の文字列が含まれるケース
  - 秋田県由利本荘市　医療法人 佐藤病院
- 括弧区切りのケース
  - 石川県穴水町　公立穴水総合病院
- マイナス記号等が使われているケース
  - 徳島県石井町　なかたに産婦人科
  
### ボタン非活性が期待されるケース
- IP電話or携帯電話番号orフリーダイヤル（050, 090, 080, 070, 060, 0800）以外の11桁を超えるケース
  - 香川県高松市　医療法人社団美術館北通り診療所
- 電話番号が12桁を超えるケース
  - 福岡県北九州市八幡西区　井上産婦人科クリニック