### PR TITLE
feat: 現在地検索で表示順を明記

### DIFF
--- a/src/app/features/medical-institutions/results-current-location/results-current-location.component.html
+++ b/src/app/features/medical-institutions/results-current-location/results-current-location.component.html
@@ -15,7 +15,8 @@
     <div class="mb-8">
       <h2 class="text-xl leading-7 font-normal">{{ shikuchoson }}周辺の医療機関</h2>
       <div class="text-sm leading-5 font-normal" *ngIf="totalItems > 0; else noItems">
-        {{ totalItems }}件の医療機関が見つかりました。
+        <p>{{ totalItems }}件の医療機関が見つかりました。</p>
+        <p>現在地から近い順に表示します。</p>
       </div>
       <ng-template class="text-sm leading-5 font-normal" #noItems>医療機関は見つかりませんでした。</ng-template>
     </div>

--- a/src/app/features/pharmacies/results-current-location/results-current-location.component.html
+++ b/src/app/features/pharmacies/results-current-location/results-current-location.component.html
@@ -15,7 +15,8 @@
     <div class="mb-8">
       <h2 class="text-xl leading-7 font-normal">{{ todofuken }}{{ shikuchoson }}の薬局</h2>
       <div class="text-sm leading-5 font-normal" *ngIf="totalItems > 0; else noItems">
-        {{ totalItems }}件の薬局が見つかりました。
+        <p>{{ totalItems }}件の薬局が見つかりました。</p>
+        <p>現在地から近い順に表示します。</p>
       </div>
       <ng-template class="text-sm leading-5 font-normal" #noItems>薬局は見つかりませんでした。</ng-template>
     </div>


### PR DESCRIPTION
## 関連 Issue
close: #118 
<!-- この PR が関連する Issue をリンクしてください。以下のように記述します。 -->
<!-- close: #123 -->

## 変更点
現在地検索の検索結果表示画面で、検索結果件数表示の下に「現在地から近い順に表示します。」の文言を追記しました。

医療機関　現在地検索
<img width="458" height="477" alt="スクリーンショット 2025-12-20 16 31 49" src="https://github.com/user-attachments/assets/8610707f-50c4-4f13-b041-4919d2684de5" />

薬局　現在地検索
<img width="453" height="457" alt="スクリーンショット 2025-12-20 16 32 05" src="https://github.com/user-attachments/assets/7d697385-6f81-464d-8ab6-d10caf914761" />

### 検索結果の表示順について
バックエンドでMongoDBからデータを取るときに、$geoNearという集計ステージを利用していることで、
結果が現在地から近い順になる実装となっています。
<!-- 具体的な変更点や修正箇所を記載してください。必要に応じて画像や動画を添付してください。　-->

## 影響範囲
なし。
<!-- 変更点以外に影響を及ぼす範囲があれば、それを記載してください。 -->

## テスト
- 医療機関検索の現在地検索で、検索結果一覧画面の表示を確認する。
- 薬局検索の現在地検索で、検索結果一覧画面の表示を確認する。
<!-- この PR に関連するテストケースやテスト方法を記載してください。 -->
